### PR TITLE
Rename settings section to "Automated tagging"

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -61,7 +61,7 @@ class Admin implements ISettings {
 		$parameters = [
 			'appid' => $this->appName,
 			'docs' => 'admin-files-automated-tagging',
-			'heading' => $this->l10n->t('Files automated tagging'),
+			'heading' => $this->l10n->t('Automated tagging'),
 			'settings-hint' => $this->l10n->t('Automatically tag files based on factors such as filetype, user group memberships, time and more.'),
 			'description' => $this->l10n->t('Each rule group consists of one or more rules. A request matches a group if all rules evaluate to true. On uploading a file all defined groups are evaluated and when matching, the given collaborative tags are assigned to the file.'),
 		];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,7 +25,7 @@ if (!defined('PHPUNIT_RUN')) {
 
 require_once __DIR__.'/../../../lib/base.php';
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if(!class_exists('PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 


### PR DESCRIPTION
From https://github.com/nextcloud/server/issues/10094

> Workflow: "Files automated tagging" should be renamed to "Automated tagging"