### PR TITLE
fix icon color to not be black on black when dark mode is enabled

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ window.OCA.WorkflowEngine.registerOperator({
 	id: 'OCA\\FilesAutomatedTagging\\Operation',
 	name: t('files_automatedtagging', 'Tag a file'),
 	description: t('files_automatedtagging'),
-	iconClass: 'icon-tag-white',
 	color: 'var(--color-success)',
 	operation: '',
 	options: Tag,


### PR DESCRIPTION
before:

![black-on-black](https://user-images.githubusercontent.com/2184312/72443347-649bf100-37ae-11ea-8e69-db9c0c456f27.png)

now

![white on black](https://user-images.githubusercontent.com/2184312/72443358-6960a500-37ae-11ea-9455-0e7ceb457b25.png)
