### PR TITLE
Rename operation trigger to file is changed

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -232,6 +232,6 @@ class Operation implements ISpecificOperation, IComplexOperation {
 	 * @since 18.0.0
 	 */
 	public function getTriggerHint(): string {
-		return $this->l->t('File is accessed');
+		return $this->l->t('File is changed');
 	}
 }


### PR DESCRIPTION
As discussed in https://github.com/nextcloud/files_automatedtagging/issues/158#issuecomment-605342450 since the access is actually checking for a `touch` on the file so that causes some confusion to non-technical users.