### PR TITLE
fix treating files and folders in external storages

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -129,7 +129,7 @@ class Operation implements ISpecificOperation, IComplexOperation {
 			return strpos($file, '__groupfolders') !== 0;
 		}
 
-		if (!$storage->isLocal()) {
+		if (!$storage->isLocal() || strpos($storage->getId(), 'local::') === 0) {
 			$mountPoints = $this->mountManager->findByStorageId($storage->getId());
 			if (!empty($mountPoints) && $mountPoints[0]->getMountType() === 'external') {
 				// it is OK to only look at the first one, if there are many

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -26,6 +26,7 @@ use OCA\GroupFolders\Mount\GroupFolderStorage;
 use OCA\WorkflowEngine\Entity\File;
 use OCP\EventDispatcher\Event;
 use OCP\Files\IHomeStorage;
+use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -57,6 +58,8 @@ class Operation implements ISpecificOperation, IComplexOperation {
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
+	/** @var IMountManager */
+	private $mountManager;
 
 	/**
 	 * @param ISystemTagObjectMapper $objectMapper
@@ -65,13 +68,22 @@ class Operation implements ISpecificOperation, IComplexOperation {
 	 * @param IL10N $l
 	 * @param IConfig $config
 	 */
-	public function __construct(ISystemTagObjectMapper $objectMapper, ISystemTagManager $tagManager, IManager $checkManager, IL10N $l, IConfig $config, IURLGenerator $urlGenerator) {
+	public function __construct(
+		ISystemTagObjectMapper $objectMapper,
+		ISystemTagManager $tagManager,
+		IManager $checkManager,
+		IL10N $l,
+		IConfig $config,
+		IURLGenerator $urlGenerator,
+		IMountManager $mountManager
+	) {
 		$this->objectMapper = $objectMapper;
 		$this->tagManager = $tagManager;
 		$this->checkManager = $checkManager;
 		$this->l = $l;
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
+		$this->mountManager = $mountManager;
 	}
 
 	/**
@@ -115,6 +127,24 @@ class Operation implements ISpecificOperation, IComplexOperation {
 		if ($storage->instanceOfStorage(GroupFolderStorage::class)) {
 			// We do not tag the roots of groupfolders, but every path inside we do
 			return strpos($file, '__groupfolders') !== 0;
+		}
+
+		if (!$storage->isLocal()) {
+			$mountPoints = $this->mountManager->findByStorageId($storage->getId());
+			if (!empty($mountPoints) && $mountPoints[0]->getMountType() === 'external') {
+				// it is OK to only look at the first one, if there are many
+				if (!empty($file)) {
+					// a file somewhere on the storage is always OK
+					return true;
+				}
+
+				// external storages are always ok as long as not mounted as user root
+				$mountPointPath = rtrim($mountPoints[0]->getMountPoint(), '/');
+				$mountPointPieces = explode('/', $mountPointPath);
+				$mountPointName = array_pop($mountPointPieces);
+				// user root structure: /$USER_ID/files
+				return ($mountPointName !== 'files' || count($mountPointPieces) !== 2);
+			}
 		}
 
 		if (substr_count($file, '/') === 0) {

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -154,17 +154,22 @@ class OperationTest extends TestCase {
 		$localId = 'local::/mnt/users/alice';
 		$smbId = 'smb::alice@ser.vr/share/thing';
 		$mountPoint = '/alice/files/NetworkDrive/';
+		$userHomeMountPoint = '/alice/files/';
 		return [
 			[Home::class, $homeId, 'trash/foo', false],
 			[Home::class, $homeId, 'files/foo', true],
 			[Home::class, $homeId, 'files', false],
-			[Local::class, $localId, 'foo', false],
+			[Local::class, $localId, '', false, $userHomeMountPoint],
+			[Local::class, $localId, 'foo', true, $userHomeMountPoint],
+			[Local::class, $localId, 'foo', true, $mountPoint],
 			[Local::class, $localId, 'appdata_instanceid/foo', false],
+			[SMB::class, $smbId, 'in-the-mountpoint.txt', true, $userHomeMountPoint],
 			[SMB::class, $smbId, 'in-the-mountpoint.txt', true, $mountPoint],
 			[SMB::class, $smbId, 'sub1/in-the-folder.md', true, $mountPoint],
+			[SMB::class, $smbId, 'somewhere/deeply/nested/so-cozy.mp4', true, $userHomeMountPoint],
 			[SMB::class, $smbId, 'somewhere/deeply/nested/so-cozy.mp4', true, $mountPoint],
 			[SMB::class, $smbId, '', true, $mountPoint],
-			[SMB::class, $smbId, '', false, '/alice/files/'],
+			[SMB::class, $smbId, '', false, $userHomeMountPoint],
 		];
 	}
 
@@ -193,7 +198,7 @@ class OperationTest extends TestCase {
 		$mountPoint = $this->createMock(IMountPoint::class);
 		$mountPoint->expects($this->any())
 			->method('getMountType')
-			->willReturn($isLocal ? '' : 'external');
+			->willReturn($mountPointPath === '' ? '' : 'external');
 		$mountPoint->expects($this->any())
 			->method('getMountPoint')
 			->willReturn($mountPointPath);


### PR DESCRIPTION
Right now, `Operation`s `isTaggingPath()` has rules specific to group folders and home storage. But external storages are bound to fail, at least when the path is close to the root on the hierarchy, because the file path is relative to the mountpoint.  I.e.  checking an incoming file "Example.md" at an external storages mounted as ' alice/files/Home'  enters the method plainly as 'Example.md' and would already fail the if `(substr_count($file, '/') === 0) {` check (fails, because it returns false).

Comes with tests.



@juliushaertl @nickvergessen 

