### PR TITLE
[ci] ensure zip and gd extensions are installed

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -47,7 +47,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite
+          extensions: mbstring, iconv, fileinfo, intl, sqlite, pdo_sqlite, zip, gd
           tools: phpunit:8.5.13
           coverage: none
 
@@ -109,7 +109,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, mysql, pdo_mysql
+          extensions: mbstring, iconv, fileinfo, intl, mysql, pdo_mysql, zip, gd
           tools: phpunit:8.5.13
           coverage: none
 
@@ -173,7 +173,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, pgsql, pdo_pgsql
+          extensions: mbstring, iconv, fileinfo, intl, pgsql, pdo_pgsql, zip, gd
           tools: phpunit:8.5.13
           coverage: none
 
@@ -232,7 +232,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, iconv, fileinfo, intl, oci8
+          extensions: mbstring, iconv, fileinfo, intl, oci8, zip, gd
           tools: phpunit:8.5.13
           coverage: none
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -229,7 +229,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.9.0
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, iconv, fileinfo, intl, oci8, zip, gd


### PR DESCRIPTION
PHP 7.3 tests are currently failing with

```
PHP module zip not installed.
Please ask your server administrator to install the module.

PHP module GD not installed.
Please ask your server administrator to install the module.

An unhandled exception has been thrown:
Exception: Environment not properly prepared. in /home/runner/work/files_automatedtagging/files_automatedtagging/lib/private/Console/Application.php:168
```