### PR TITLE
Also tag group folder root

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -115,7 +115,11 @@ class Operation implements ISpecificOperation, IComplexOperation {
 
 	public function isTaggingPath(IStorage $storage, string $file): bool {
 		if ($storage->instanceOfStorage(GroupFolderStorage::class)) {
-			// We do not tag the roots of groupfolders, but every path inside we do
+			// note: $storage only matches if group folder already exists, otherwise it's a local storage
+			// with the group folder root on top.
+
+			// $file can be "__groupfolders/$id" or a relative path inside it
+			// We do not (re-)tag the roots of groupfolders, but every path inside we do
 			return strpos($file, '__groupfolders') !== 0;
 		}
 
@@ -145,11 +149,13 @@ class Operation implements ISpecificOperation, IComplexOperation {
 			[$folder] = explode('/', $file, 2);
 			return $folder === 'files';
 		} else {
-			[$folder, $subPath] = explode('/', $file, 2);
+			[$folder, $subPath] = explode('/', $file, 3);
 			// the root folder only contains appdata and home mounts
 			// anything in a non homestorage and not in the appdata folder
 			// should be a mounted folder
-			return $folder !== $this->getAppDataFolderName() && substr_count($subPath, '/') >= 1;
+			return ($folder !== $this->getAppDataFolderName() && substr_count($subPath, '/') >= 1)
+				// also match group folder root creation
+				|| ($folder === '__groupfolders' && is_numeric($subPath));
 		}
 	}
 


### PR DESCRIPTION
The code path for group folder root cache entry creation goes through the local storages, not the group folder one. So we allow to tag there.

The existing instanceOf() code path is only hit after the group folder was already mounted, so we leave it as is.

- [x] TEST: group folder root id is tagged
- [x] TEST: group folder contents also still tagged properly

:warning: BACKPORT WARNING :warning: 

On server master + this branch it works as expected.

On stable24 where I debugged this initially I noticed that the CacheInsertEvent was triggered for more entries than necessary, so when backporting this needs to be fully retested to make sure we don't tag more than necessary.
And there's also a risk that the group folder detection logic is different in past versions (unless I took a wrong turn in my various attempts), still, better to retest there.
