### PR TITLE
[stable27] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6af8fc960e0526d3641b8c0da9cbf0d5a85be920"
+                "reference": "231772a8551fb872f768b5cf028acf2cd2447b70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6af8fc960e0526d3641b8c0da9cbf0d5a85be920",
-                "reference": "6af8fc960e0526d3641b8c0da9cbf0d5a85be920",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/231772a8551fb872f768b5cf028acf2cd2447b70",
+                "reference": "231772a8551fb872f768b5cf028acf2cd2447b70",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-08-02T00:37:00+00:00"
+            "time": "2023-08-09T17:38:35+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency