### PR TITLE
[stable27] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "7bc1e99e95f489e139aab4fbecfea2575977bb28"
+                "reference": "4d7a5c906a44acff4d27650fabbb473fd3307b37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/7bc1e99e95f489e139aab4fbecfea2575977bb28",
-                "reference": "7bc1e99e95f489e139aab4fbecfea2575977bb28",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4d7a5c906a44acff4d27650fabbb473fd3307b37",
+                "reference": "4d7a5c906a44acff4d27650fabbb473fd3307b37",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2024-05-09T00:34:04+00:00"
+            "time": "2024-05-28T00:35:06+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency