### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3462,9 +3462,9 @@
       }
     },
     "node_modules/@nextcloud/vue-select": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.25.0.tgz",
-      "integrity": "sha512-zILFuJmUxp2oY09QUE65u69SxoQaR0RJdfnkpQlj2hcvzyOTLkYuyZwpxvseCf31WZnh9i2MO5mAddhsDCmw5g==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.25.1.tgz",
+      "integrity": "sha512-jqCi4G+Q0H6+Hm8wSN3vRX2+eXG2jXR2bwBX/sErVEsH5UaxT4Nb7KqgdeIjVfeF7ccIdRqpmIb4Pkf0lao67w==",
       "engines": {
         "node": "^20.0.0"
       },
@@ -7698,9 +7698,9 @@
       "peer": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -9917,9 +9917,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -18811,9 +18811,9 @@
       "peer": true
     },
     "node_modules/vue2-datepicker": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.11.0.tgz",
-      "integrity": "sha512-zbMkAjYwDTXZozZtkpSwqxq7nEeBt7zoHL+oQcdjEXAqzJHhmatE6sl6JSr58PMIx2WOK0c6QBXozSqT32iQAQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-3.11.1.tgz",
+      "integrity": "sha512-6PU/+pnp2mgZAfnSXmbdwj9516XsEvTiw61Q5SNrvvdy8W/FCxk1GAe9UZn/m9YfS5A47yK6XkcjMHbp7aFApA==",
       "dependencies": {
         "date-format-parse": "^0.2.7"
       },


### PR DESCRIPTION
# Audit report

This audit fix resolves 8 of the total 17 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [elliptic](#user-content-elliptic)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Valid ECDSA signatures erroneously rejected in Elliptic
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-fc9h-whq2-v747](https://github.com/advisories/GHSA-fc9h-whq2-v747)
* Affected versions: <6.6.0
* Package usage:
  * `node_modules/elliptic`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* Denial of service in http-proxy-middleware
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27)
* Affected versions: <2.0.7
* Package usage:
  * `node_modules/http-proxy-middleware`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`