### PR TITLE
fix: do error on upload when a tag is not found anymore

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -14,7 +14,6 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\Files\Cache\CacheEntryInsertedEvent;
 use OCP\Files\Cache\CacheEntryUpdatedEvent;
 use OCP\WorkflowEngine\Events\RegisterOperationsEvent;
 
@@ -27,7 +26,6 @@ class Application extends App implements IBootstrap {
 
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
-		$context->registerEventListener(CacheEntryInsertedEvent::class, CacheListener::class);
 		$context->registerEventListener(CacheEntryUpdatedEvent::class, CacheListener::class);
 
 		$context->registerEventListener(RegisterOperationsEvent::class, RegisterFlowOperationsListener::class);

--- a/tests/OperationTest.php
+++ b/tests/OperationTest.php
@@ -30,6 +30,7 @@ use OCP\SystemTag\TagNotFoundException;
 use OCP\WorkflowEngine\IManager;
 use OCP\WorkflowEngine\IRuleMatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class OperationTest extends TestCase {
@@ -45,6 +46,7 @@ class OperationTest extends TestCase {
 	protected \OCA\WorkflowEngine\Entity\File&MockObject $fileEntity;
 	protected IUserSession&MockObject $userSession;
 	protected IGroupManager&MockObject $groupManager;
+	protected LoggerInterface&MockObject $logger;
 	protected Operation $operation;
 
 	protected function setUp(): void {
@@ -62,6 +64,7 @@ class OperationTest extends TestCase {
 		$this->fileEntity = $this->createMock(\OCA\WorkflowEngine\Entity\File::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->checkManager->expects($this->any())
 			->method('getRuleMatcher')
@@ -81,7 +84,8 @@ class OperationTest extends TestCase {
 			$this->rootFolder,
 			$this->fileEntity,
 			$this->userSession,
-			$this->groupManager
+			$this->groupManager,
+			$this->logger,
 		);
 	}
 


### PR DESCRIPTION
- als removes a listener to CacheEntryInsertedEvent since CacheEntryUpdatedEvent will be called as well
- logs a warning instead

fixes #1211 

Example log statements:

```json
{"reqId":"BXmsa5WqWcnyRe88EESb","level":2,"time":"2025-08-06T15:41:15+00:00","remoteAddr":"127.0.0.1","user":"spider","app":"files_automatedtagging","method":"PUT","url":"/remote.php/dav/files/spider/CanIHaz/error(2).jpeg","message":"The tag to assign (ID 77) cannot be found anymore. The related rule is owned by spider.","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0","version":"32.0.0.1","data":{"app":"files_automatedtagging"}}

{"reqId":"BXmsa5WqWcnyRe88EESb","level":2,"time":"2025-08-06T15:41:16+00:00","remoteAddr":"127.0.0.1","user":"spider","app":"files_automatedtagging","method":"PUT","url":"/remote.php/dav/files/spider/CanIHaz/error(2).jpeg","message":"The tag to assign (ID 106) cannot be found anymore. The related rule is global.","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:141.0) Gecko/20100101 Firefox/141.0","version":"32.0.0.1","data":{"app":"files_automatedtagging"}}
```

Also comes with a little log spamming prevention, as the source events are apprently issued twice at least.