### PR TITLE
[stable31] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2346,15 +2346,22 @@
       }
     },
     "node_modules/@nextcloud/capabilities": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.0.tgz",
-      "integrity": "sha512-L1NQtOfHWzkfj0Ple1MEJt6HmOHWAi3y4qs+OnwSWexqJT0DtXTVPyRxi7ADyITwRxS5H9R/HMl6USAj4Nr1nQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.1.tgz",
+      "integrity": "sha512-snZ0/910zzwN6PDsIlx2Uvktr1S5x0ClhDUnfPlCj7ntNvECzuVHNY5wzby22LIkc+9ZjaDKtCwuCt2ye+9p/Q==",
       "dependencies": {
-        "@nextcloud/initial-state": "^2.1.0"
+        "@nextcloud/initial-state": "^3.0.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/capabilities/node_modules/@nextcloud/initial-state": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+      "integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/eslint-config": {
@@ -2518,15 +2525,14 @@
       }
     },
     "node_modules/@nextcloud/router": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.0.1.tgz",
-      "integrity": "sha512-Ci/uD3x8OKHdxSqXL6gRJ+mGJOEXjeiHjj7hqsZqVTsT7kOrCjDf0/J8z5RyLlokKZ0IpSe+hGxgi3YB7Gpw3Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-3.1.0.tgz",
+      "integrity": "sha512-e4dkIaxRSwdZJlZFpn9x03QgBn/Sa2hN1hp/BA7+AbzykmSAlKuWfdmX8j/8ewrLpQwYmZR23IZO9XwpJXq2Uw==",
       "dependencies": {
-        "@nextcloud/typings": "^1.7.0"
+        "@nextcloud/typings": "^1.10.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/sharing": {
@@ -2579,33 +2585,32 @@
       }
     },
     "node_modules/@nextcloud/typings": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.9.1.tgz",
-      "integrity": "sha512-i0l/L5gKW8EACbXHVxXM6wn3sUhY2qmnL2OijppzU4dENC7/hqySMQDer7/+cJbNSNG7uHF/Z+9JmHtDfRfuGg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.10.0.tgz",
+      "integrity": "sha512-SMC42rDjOH3SspPTLMZRv76ZliHpj2JJkF8pGLP8l1QrVTZxE47Qz5qeKmbj2VL+dRv2e/NgixlAFmzVnxkhqg==",
       "dependencies": {
         "@types/jquery": "3.5.16"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.34.0.tgz",
-      "integrity": "sha512-zUmInTvT4NgbRjWJZbw8nA+h4EqitYKfoCTj3h3Xr930sQZcczQatPtSo5Sps8RAh+JJz3iiAqAawYqS9jvBdA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.35.0.tgz",
+      "integrity": "sha512-qPm0aaPbnt7n694WQ97T+EMQTxCa3+RPKDzsBVD6vb01N4uGYwjvrEEOLVmBMlEWqkFy+ks3tpeOjkDPOoJbNA==",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@linusborg/vue-simple-portal": "^0.1.5",
         "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.5.0",
-        "@nextcloud/capabilities": "^1.2.0",
-        "@nextcloud/event-bus": "^3.3.2",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/event-bus": "^3.3.3",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.4.0",
+        "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/logger": "^3.0.2",
-        "@nextcloud/router": "^3.0.1",
+        "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.3.0",
         "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.26.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 13 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/webpack-vue-config](#user-content-\\@nextcloud\\/webpack-vue-config)
## Fixed vulnerabilities

### `@nextcloud/webpack-vue-config` <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`