### PR TITLE
fix: listen to CacheEntryInsertedEvent again

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Files\Cache\CacheEntryInsertedEvent;
 use OCP\Files\Cache\CacheEntryUpdatedEvent;
 use OCP\WorkflowEngine\Events\RegisterOperationsEvent;
 
@@ -26,6 +27,9 @@ class Application extends App implements IBootstrap {
 
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
+		// While both Inserted and Updated are sometimes triggered, only Inserted is trigged when
+		// a file/folder is created in a files_external mount externally and the user navigates to it
+		$context->registerEventListener(CacheEntryInsertedEvent::class, CacheListener::class);
 		$context->registerEventListener(CacheEntryUpdatedEvent::class, CacheListener::class);
 
 		$context->registerEventListener(RegisterOperationsEvent::class, RegisterFlowOperationsListener::class);


### PR DESCRIPTION
- Reverting https://github.com/nextcloud/files_automatedtagging/commit/3beb8e72fb9f79754c7ba2c7b6324be58de99b50 partly
- Fix https://github.com/nextcloud/files_automatedtagging/issues/902