### PR TITLE
fix: Trigger tagging for per-folder storage groupfolders

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,7 @@
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="OCA\GroupFolders\Mount\GroupFolderStorage" />
+				<referencedClass name="OCA\GroupFolders\Mount\GroupMountPoint" />
 				<referencedClass name="OCA\WorkflowEngine\Entity\File" />
 			</errorLevel>
 		</UndefinedClass>


### PR DESCRIPTION
Best reviewed without whitespace diff.
For groupfolders with their own storage the checks for `__groupfolders` do not match, because they use their own local storage, which is not distinguishable from other local storages.
Using the mountpoint works correctly in my testing, but I'm not sure if this catches all cases where it should return true.