### PR TITLE
[stable31] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,17 +2572,6 @@
         "stylelint-config-recommended-vue": "^1.5.0"
       }
     },
-    "node_modules/@nextcloud/timezones": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
-      "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
-      "dependencies": {
-        "ical.js": "^2.1.0"
-      },
-      "engines": {
-        "node": "^20 || ^22"
-      }
-    },
     "node_modules/@nextcloud/typings": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.10.0.tgz",
@@ -2595,9 +2584,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.35.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.35.2.tgz",
-      "integrity": "sha512-a6ztaJAyIqh09hDLWeT72fJL//cse/D9ZuVyB37TSHBLPFBxNwyFDZu+EEuR0veBb6AnSoVI8+O/C81pmFGXkw==",
+      "version": "8.35.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.35.3.tgz",
+      "integrity": "sha512-Znfm3MwejKyDNdFIVRyZGfMruqrLz/Zf3x0zrWHZ03qHSJqopCdeTgvFys4+6PWDAg9ujhja5kUx6XCcZx6Qyw==",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -2611,7 +2600,6 @@
         "@nextcloud/logger": "^3.0.3",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/timezones": "^0.2.0",
         "@nextcloud/vue-select": "^3.26.0",
         "@vueuse/components": "^11.0.0",
         "@vueuse/core": "^11.0.0",
@@ -2622,7 +2610,7 @@
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
-        "focus-trap": "7.6.6",
+        "focus-trap": "^7.8.0",
         "linkify-string": "^4.3.2",
         "md5": "^2.3.0",
         "p-queue": "^8.1.1",
@@ -7469,11 +7457,11 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.6.6",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.6.tgz",
-      "integrity": "sha512-v/Z8bvMCajtx4mEXmOo7QEsIzlIOqRXTIwgUfsFOF9gEsespdbD0AkPIka1bSXZ8Y8oZ+2IVDQZePkTfEHZl7Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
       "dependencies": {
-        "tabbable": "^6.3.0"
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -8252,11 +8240,6 @@
       "engines": {
         "node": ">=10.18"
       }
-    },
-    "node_modules/ical.js": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
-      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -9249,9 +9232,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "peer": true
     },


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 19 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/webpack-vue-config](#user-content-\\@nextcloud\\/webpack-vue-config)
## Fixed vulnerabilities

### `@nextcloud/webpack-vue-config` <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [node-polyfill-webpack-plugin](#user-content-node-polyfill-webpack-plugin)
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`