### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,24 +1,24 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-7d1eaa7241ac797758ca4522b96357f7 appstore-build-publish.yml
+c5ce8fbd4caa30c89fb31be5a9aeb25d appstore-build-publish.yml
 d81e4f0f0b5c64bb42e703ba521f7594 command-compile.yml
 003108ea0f5c12e1db591cd4613304d8 dependabot-approve-merge.yml
 46a85bafa72379c179dd633e34abe000 lint-eslint.yml
 784303cf47612e5c4eac621dfab5b4f4 lint-info-xml.yml
-4f7ee6ee721c4646c0b78be5b08281a2 lint-php-cs.yml
-5641ed31bf9a8b1841fffbea34dbd7b2 lint-php.yml
+bb17aa6898f48f4caa83922c343731dc lint-php-cs.yml
+70673e479df96e3e71fe966cb07c82fa lint-php.yml
 a5238a69743b834ad15f2e4354b98dbd lint-stylelint.yml
 03759c9dc0fa748cb927b9f9cadf2925 node.yml
 08570256d6bbb9cd33a905b16c742f8d npm-audit-fix.yml
-317b62dd13f504ddaeed62e628e439ca phpunit-mariadb.yml
-690f9324b33d3785798689197b433c4a phpunit-mysql.yml
-6aefa02e0968c797bb81d1b2f0f49ff6 phpunit-oci.yml
-39c5ecedabc9e08ff8bf4baecaeb19e6 phpunit-pgsql.yml
-e1d06d273d1f32cb839d8b2acc4982bc phpunit-sqlite.yml
+883b4be7752bdbc342b6dbf7794dc378 phpunit-mariadb.yml
+52f8aa335a0a3ca1eeee7380854ff5ad phpunit-mysql.yml
+69b6d61696a328b8a17ad4aa6cb2a059 phpunit-oci.yml
+8e00d464a8ef10740b95dc2132244626 phpunit-pgsql.yml
+a7ae3a2b7529b41dae1302420eb72454 phpunit-sqlite.yml
 3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
-2f5f5a0851cc4bf00a0b89d009ab258a psalm.yml
+a6e484812c25ced8bb714182656e0ab1 psalm.yml
 e2bd0fc8a290e1a8641487944e27103b reuse.yml
 e3c7b8f43850ad1d31c67fc0082b6bb8 sync-workflow-templates.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
-942a700573ae377e4b7777470d5739cf update-nextcloud-ocp.yml
+eb943a065c2a0711c14468fa76629eae update-nextcloud-ocp.yml
 21036682b2608cb871b19731ffeef31f npm-build.yml

--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -88,7 +88,7 @@ jobs:
           filename: ${{ env.APP_NAME }}/appinfo/info.xml
 
       - name: Set up php ${{ steps.php-versions.outputs.php-min }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ steps.php-versions.outputs.php-min }}
           coverage: none

--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
 
       - name: Set up php${{ steps.versions.outputs.php-min }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ steps.versions.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -34,7 +34,7 @@ jobs:
         uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
 
   php-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
     needs: matrix
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -105,7 +105,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -103,7 +103,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -115,7 +115,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -106,7 +106,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -95,7 +95,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -36,7 +36,7 @@ jobs:
         run: grep 'phpVersion="${{ steps.versions.outputs.php-min }}' psalm.xml
 
       - name: Set up php${{ steps.versions.outputs.php-available }}
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ steps.versions.outputs.php-available }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -21,6 +21,9 @@ jobs:
   update-nextcloud-ocp:
     runs-on: ubuntu-latest
 
+    # Only allowed to be run on nextcloud repositories
+    if: ${{ github.repository_owner == 'nextcloud' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +46,7 @@ jobs:
 
       - name: Set up php8.3
         if: steps.checkout.outcome == 'success'
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: 8.3
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [appstore-build-publish.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/appstore-build-publish.yml)
- 🆙 Updated [lint-php-cs.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php-cs.yml)
- 🆙 Updated [lint-php.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-php.yml)
- 🆙 Updated [phpunit-mariadb.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mariadb.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
- 🆙 Updated [phpunit-oci.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-oci.yml)
- 🆙 Updated [phpunit-pgsql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-pgsql.yml)
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)
- 🆙 Updated [psalm.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/psalm.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)